### PR TITLE
feat: ヒートマップをデイリーの累計ログイン時間に変更

### DIFF
--- a/src/components/LoginHistoryTable.vue
+++ b/src/components/LoginHistoryTable.vue
@@ -8,8 +8,8 @@
         v-if="!loadingHeatmap"
         :values="heatmaps"
         :end-date="today"
-        :max="10"
-        :tooltip-unit="'login'"
+        :max="86400"
+        :tooltip-unit="'sec'"
       />
     </div>
 
@@ -139,7 +139,7 @@ export default Vue.extend({
       })
       this.$recaptcha.execute('login').then((token: string) => {
         axios
-          .get(`https://api.jaoafa.com/v2/users/login`, {
+          .get(`https://api.jaoafa.com/v2/users/daily-online`, {
             params: {
               uuid: DataStore.getUUID,
               recaptcha: token,


### PR DESCRIPTION
各ユーザーページに表示されるヒートマップがその日の累計ログイン時間で表記されるようになります（単位は秒）。

デイリーのログイン時間は MyMaid [v4.40.0](https://github.com/jaoafa/MyMaid4/releases/tag/v4.40.0) で実装された毎日のオンライン時間測定([#889](https://github.com/jaoafa/MyMaid4/pull/889))に基づくものです。
実装より前のログイン時間についてはログファイルからパース・集計しDBに集積しました。

## Screenshot

![20220730-053643-chrome-64WrV13AFa](https://user-images.githubusercontent.com/8929706/181839725-6583f149-d1fc-4578-9a76-69a121c29b8a.png)
![20220730-053706-chrome-nqgx08sjv8](https://user-images.githubusercontent.com/8929706/181839732-47502005-69c1-4af7-84c3-8656c76a5c6b.png)
![20220730-053729-chrome-7SOzkXvtRH](https://user-images.githubusercontent.com/8929706/181839735-dae1ed94-4e08-4b56-98cb-3713d169eb94.png)
